### PR TITLE
Enable Enter key to add tasks in Kanban app

### DIFF
--- a/docs/pages/_static/apps/kanban-board/kanban-board.js
+++ b/docs/pages/_static/apps/kanban-board/kanban-board.js
@@ -28,13 +28,22 @@ function render() {
     });
 }
 
-addBtn.addEventListener('click', () => {
+function addTask() {
     const text = taskInput.value.trim();
     if (!text) return;
     tasks.push({ id: Date.now().toString(), text, status: 'todo' });
     taskInput.value = '';
     saveTasks();
     render();
+}
+
+addBtn.addEventListener('click', addTask);
+
+taskInput.addEventListener('keydown', e => {
+    if (e.key === 'Enter') {
+        e.preventDefault();
+        addTask();
+    }
 });
 
 [todoCol, progressCol, doneCol].forEach(col => {

--- a/docs/pages/javascript-of-the-day/kanban-board.md
+++ b/docs/pages/javascript-of-the-day/kanban-board.md
@@ -21,7 +21,7 @@ The **Kanban Board App** is a simple yet powerful task management tool that lets
 
 ### Features
 
-- **Add Tasks:** Enter a description and press **Add** to create a new task in the **To Do** column.
+- **Add Tasks:** Enter a description and press **Add** or hit **Enter** to create a new task in the **To Do** column.
 - **Drag and Drop:** Move tasks between columns to track progress.
 - **Persistent Storage:** The board state is saved in `localStorage`.
 
@@ -31,7 +31,7 @@ Demonstrates Codex's ability to build a more sophisticated application with drag
 
 ### How It Works
 
-1. **Create Tasks:** Type a task description and click **Add**. The task appears in the **To Do** column.
+1. **Create Tasks:** Type a task description, press **Enter** or click **Add**. The task appears in the **To Do** column.
 2. **Move Tasks:** Drag a task card to a different column to update its status.
 3. **Reload:** Refreshing the page restores your tasks from `localStorage`.
 


### PR DESCRIPTION
## Summary
- allow tasks to be added on Enter keypress
- document the Enter behavior in the Kanban Board notes

## Testing
- `pip install -r requirements.txt`
- `mkdocs build -f docs/mkdocs.yml -q`

------
https://chatgpt.com/codex/tasks/task_b_687966c7519c832db395c7a6fd32f43d