### PR TITLE
Fix Enter key for Kanban board

### DIFF
--- a/docs/pages/_static/apps/kanban-board/kanban-board.js
+++ b/docs/pages/_static/apps/kanban-board/kanban-board.js
@@ -39,8 +39,8 @@ function addTask() {
 
 addBtn.addEventListener('click', addTask);
 
-taskInput.addEventListener('keydown', e => {
-    if (e.key === 'Enter') {
+taskInput.addEventListener('keyup', e => {
+    if (e.key === 'Enter' || e.keyCode === 13) {
         e.preventDefault();
         addTask();
     }


### PR DESCRIPTION
## Summary
- ensure pressing Enter adds a Kanban task

## Testing
- `node - <<'NODE'
const puppeteer=require('puppeteer');
(async()=>{const b=await puppeteer.launch({headless:true,args:['--no-sandbox']});const p=await b.newPage();await p.goto('http://localhost:8000/kanban-board.html');await p.waitForSelector('#taskInput');await p.type('#taskInput','TaskX');await p.keyboard.press('Enter');await new Promise(r=>setTimeout(r,500));console.log('Tasks:',await p.$$eval('#todo .task',els=>els.map(el=>el.textContent)));await b.close();})();
NODE`

------
https://chatgpt.com/codex/tasks/task_b_68796de90ad8832db2290ddf2cbb373f