### PR TITLE
Add global Enter key handler for Kanban Board

### DIFF
--- a/docs/pages/_static/apps/kanban-board/kanban-board.js
+++ b/docs/pages/_static/apps/kanban-board/kanban-board.js
@@ -39,8 +39,11 @@ function addTask() {
 
 addBtn.addEventListener('click', addTask);
 
-taskInput.addEventListener('keyup', e => {
+document.addEventListener('keydown', e => {
     if (e.key === 'Enter' || e.keyCode === 13) {
+        const tag = e.target.tagName.toLowerCase();
+        if (tag === 'textarea') return;
+        if (tag === 'input' && e.target !== taskInput) return;
         e.preventDefault();
         addTask();
     }


### PR DESCRIPTION
## Summary
- allow pressing Enter anywhere to add a Kanban TODO

## Testing
- `python -m compileall .`

------
https://chatgpt.com/codex/tasks/task_b_687972090ef4832db9b0c866b539fa6a